### PR TITLE
fix: update style.css

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -58,16 +58,11 @@ body {
 .info-wrapper {
 	position: absolute;
 	bottom: 15px;
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	width: 100%;
+	left: 50%;
+	transform: translate(-50%);
 }
 
 #info_box {
-	display: flex;
-	justify-content: center;
-	align-items: center;
 	background: rgba(255, 255, 255, 0.8);
 	border-radius: 15px;
 	padding: 15px 20px;


### PR DESCRIPTION
Simplify CSS for overlay menu and solve error with 100% width avoiding to use part of the map (no zoom, no popup, etc)
Check here: https://kikocorreoso.github.io/omaps/ (click over the map on the left or right of the overlay menu) in comparison to https://open-meteo.github.io/omaps/